### PR TITLE
Implement interrupt-based wheel encoders.

### DIFF
--- a/encoders.cpp
+++ b/encoders.cpp
@@ -1,6 +1,119 @@
-#include <Arduino.h>
+#include "include/encoders.hpp"
 
-static constexpr uint8_t rightA0 = A0;
-static constexpr uint8_t rightD0 = A1;
-static constexpr uint8_t leftA0 = A2;
-static constexpr uint8_t leftD0 = A3;
+#include <avr/interrupt.h>
+
+#define leftPin PIN_A1
+#define rightPin PIN_A0
+
+#if leftPin <= 7
+#define leftPinPort 2
+#elif leftPin <= 13
+#define leftPinPort 0
+#else
+#define leftPinPort 1
+#endif
+
+#if rightPin <= 7
+#define rightPinPort 2
+#elif rightPin <= 13
+#define rightPinPort 0
+#else
+#define rightPinPort 1
+#endif
+
+static constexpr uint8_t leftPCICRbit = digitalPinToPCICRbit(leftPin);
+static constexpr uint8_t rightPCICRbit = digitalPinToPCICRbit(rightPin);
+
+static constexpr uint8_t leftPCMSKbit = digitalPinToPCMSKbit(leftPin);
+static constexpr uint8_t rightPCMSKbit = digitalPinToPCMSKbit(rightPin);
+
+static volatile uint16_t leftTicks;
+static volatile uint16_t rightTicks;
+
+static uint8_t prevPinStates = 0;
+
+#if rightPinPort != leftPinPort
+static uint8_t prevPinStates2 = 0;
+#endif
+
+void Encoders::init() {
+    pinMode(leftPin, INPUT);
+    pinMode(rightPin, INPUT);
+
+    leftTicks = 0;
+    rightTicks = 0;
+
+    // enable pin change interrupts for relevant ports
+    constexpr uint8_t PCICR_MASK = bit(leftPCICRbit) | bit(rightPCICRbit);
+    PCICR |= PCICR_MASK;
+
+    // set interrupt masks to allow left and right pins
+    *digitalPinToPCMSK(leftPin) |= bit(leftPCMSKbit);
+    *digitalPinToPCMSK(rightPin) |= bit(rightPCMSKbit);
+}
+
+uint16_t Encoders::getLeftTicks() {
+    // disable left encoder interrupt
+    *digitalPinToPCMSK(leftPin) &= ~bit(leftPCMSKbit);
+
+    const uint16_t out = leftTicks;
+
+    // re-enable interrupt
+    *digitalPinToPCMSK(leftPin) |= bit(leftPCMSKbit);
+    return out;
+}
+
+uint16_t Encoders::getRightTicks() {
+    // disable right encoder interrupt
+    *digitalPinToPCMSK(rightPin) &= ~bit(rightPCMSKbit);
+
+    const uint16_t out = rightTicks;
+
+    // re-enable interrupt
+    *digitalPinToPCMSK(rightPin) |= bit(rightPCMSKbit);
+    return out;
+}
+
+#if leftPinPort == 0
+ISR(PCINT0_vect) {
+    const uint8_t pinChanges = PINB ^ prevPinStates;
+#elif leftPinPort == 1
+ISR(PCINT1_vect) {
+    const uint8_t pinChanges = PINC ^ prevPinStates;
+#else
+ISR(PCINT2_vect) {
+    const uint8_t pinChanges = PIND ^ prevPinStates;
+#endif
+
+    if (pinChanges & bit(leftPCMSKbit)) {
+        leftTicks++;
+    }
+
+#if rightPinPort == leftPinPort
+    if (pinChanges & bit(rightPCMSKbit)) {
+        rightTicks++;
+    }
+#endif
+
+    prevPinStates ^= pinChanges;
+}
+
+#if rightPinPort != leftPinPort
+#if rightPinPort == 0
+ISR(PCINT0_vect) {
+    const uint8_t pinChanges = PINB ^ prevPinStates2;
+#elif rightPinPort == 1
+ISR(PCINT1_vect) {
+    const uint8_t pinChanges = PINC ^ prevPinStates2;
+#else
+ISR(PCINT2_vect) {
+    const uint8_t pinChanges = PIND ^ prevPinStates2;
+#endif
+
+    if (pinChanges & bit(rightPCMSKbit)) {
+        Encoders::rightTicks++;
+    }
+
+    prevPinStates2 ^= pinChanges;
+}
+#endif

--- a/encoders.cpp
+++ b/encoders.cpp
@@ -53,24 +53,24 @@ void Encoders::init() {
 }
 
 uint16_t Encoders::getLeftTicks() {
-    // disable left encoder interrupt
-    *digitalPinToPCMSK(leftPin) &= ~bit(leftPCMSKbit);
+    // disable interrupts
+    cli();
 
     const uint16_t out = leftTicks;
 
-    // re-enable interrupt
-    *digitalPinToPCMSK(leftPin) |= bit(leftPCMSKbit);
+    // re-enable interrupts
+    sei();
     return out;
 }
 
 uint16_t Encoders::getRightTicks() {
-    // disable right encoder interrupt
-    *digitalPinToPCMSK(rightPin) &= ~bit(rightPCMSKbit);
+    // disable interrupts
+    cli();
 
     const uint16_t out = rightTicks;
 
     // re-enable interrupt
-    *digitalPinToPCMSK(rightPin) |= bit(rightPCMSKbit);
+    sei();
     return out;
 }
 

--- a/include/encoders.hpp
+++ b/include/encoders.hpp
@@ -1,5 +1,24 @@
 #pragma once
 
+#include <Arduino.h>
+
 namespace Encoders {
-    
-}
+
+/**
+ * Initiate the encoder library, setting pin modes and interrupts.
+ */
+void init();
+
+/**
+ * Gets the number of times the left encoder has ticked.
+ * @return The number of left encoder ticks since init was called.
+ */
+uint16_t getLeftTicks();
+
+/**
+ * Gets the number of times the right encoder has ticked.
+ * @return The number of right encoder ticks since init was called.
+ */
+uint16_t getRightTicks();
+
+} // namespace Encoders

--- a/main.ino
+++ b/main.ino
@@ -14,9 +14,9 @@ void setup() {
     Drivebase::setDeadzone(deadzone);
 }
 
-void autonomous() {}
+static void autonomous() {}
 
-void teleop() { Drivebase::arcadeDrive(ds->getLY(), ds->getLX()); }
+static void teleop() { Drivebase::arcadeDrive(ds->getLY(), ds->getLX()); }
 
 void loop() {
     // update the DriverStation class - this will check if there is new data

--- a/main.ino
+++ b/main.ino
@@ -2,6 +2,7 @@
 
 #include "include/drivebase.hpp"
 #include "include/tasks.hpp"
+#include "include/encoders.hpp"
 
 static ElegooCar *joebot = new ElegooCar();
 static DriverStation *ds = new DriverStation();
@@ -12,6 +13,7 @@ void setup() {
     Serial.begin(115200);
     Drivebase::init(joebot);
     Drivebase::setDeadzone(deadzone);
+    Encoders::init();
 }
 
 static void autonomous() {}


### PR DESCRIPTION
The motors for the drivebase of the robot are attached to wheels with beam break sensors to allow for tracking the rotation of the wheels. This PR adds a new Encoders module which tracks the number of edges from the beam break sensors using interrupts.

This should allow the program to track how far the robot is moving, although the direction of rotation cannot be determined. It should be fairly trivial to add functionality to track the speed of the robot.

Interrupt-safety is handled by the getLeftTicks() and getRightTicks() functions. Encoder ticks are stored in 16 bits and therefore cannot be atomically accessed by the Arduino UNO's 8-bit CPU. To ensure that an encoder-tick interrupt doesn't trigger in mid-read, interrupts are temporarily disabled during the read operation. Any interrupt triggered during this time will automatically be handled by the CPU once interrupts re-enabled.