### PR TITLE
Implement Grabber servo control

### DIFF
--- a/grabber.cpp
+++ b/grabber.cpp
@@ -3,45 +3,56 @@
 
 #include <Servo.h>
 
-static constexpr uint8_t grabberServoPin = 3;
+static constexpr uint8_t GRABBER_SERVO_PIN = 3;
 
-static uint8_t servoDeadzone = 0;
-static uint8_t servoAngle = 0;
+static constexpr uint8_t MIN_ANGLE = 0;
+static constexpr uint8_t MAX_ANGLE = 180;
 
 static Servo grabberServo;
 
-void Grabber::init() {
-    grabberServo.attach(grabberServoPin);
-    grabberServo.write(servoAngle);
+static uint8_t grabberServoDeadzone = 0;
+static uint8_t grabberServoAngle = MIN_ANGLE;
+
+static inline uint8_t grabberClamp8(uint8_t angle) {
+    return Util::clamp_8(angle, MIN_ANGLE, MAX_ANGLE);
 }
 
-void Grabber::setDeadzone(uint8_t deadzone) { servoDeadzone = deadzone; }
+static inline int16_t grabberClamp16(int16_t angle) {
+    return Util::clamp_16(angle, MIN_ANGLE, MAX_ANGLE);
+}
+
+void Grabber::init() {
+    grabberServo.attach(GRABBER_SERVO_PIN);
+    grabberServo.write(grabberServoAngle);
+}
+
+void Grabber::setDeadzone(uint8_t deadzone) { grabberServoDeadzone = deadzone; }
 
 void Grabber::setAngle(uint8_t degrees) {
-    servoAngle = Util::clamp_8(degrees, 0, 180);
-    grabberServo.write(servoAngle);
+    grabberServoAngle = grabberClamp8(degrees);
+    grabberServo.write(grabberServoAngle);
 }
 
 void Grabber::changeAngle(int16_t degrees) {
-    if (degrees < servoDeadzone) {
+    if (abs(degrees) < grabberServoDeadzone) {
         return;
     }
-    servoAngle = Util::clamp_16(servoAngle + degrees, 0, 180);
-    grabberServo.write(servoAngle);
+    grabberServoAngle = grabberClamp16(grabberServoAngle + degrees);
+    grabberServo.write(grabberServoAngle);
 }
 
 void Grabber::moveUp(uint8_t degrees) {
-    if (degrees < servoDeadzone) {
+    if (degrees < grabberServoDeadzone) {
         return;
     }
-    servoAngle = Util::clamp_16(servoAngle + degrees, 0, 180);
-    grabberServo.write(servoAngle);
+    grabberServoAngle = grabberClamp16(grabberServoAngle + degrees);
+    grabberServo.write(grabberServoAngle);
 }
 
 void Grabber::moveDown(uint8_t degrees) {
-    if (degrees < servoDeadzone) {
+    if (degrees < grabberServoDeadzone) {
         return;
     }
-    servoAngle = Util::clamp_16(servoAngle - degrees, 0, 180);
-    grabberServo.write(servoAngle);
+    grabberServoAngle = grabberClamp16(grabberServoAngle - degrees);
+    grabberServo.write(grabberServoAngle);
 }

--- a/grabber.cpp
+++ b/grabber.cpp
@@ -13,7 +13,10 @@ static uint8_t clampRange(uint8_t input) {
     return input < 0 ? 0 : input > 180 ? 180 : input;
 }
 
-void Grabber::init() { grabberServo.attach(grabberServoPin); }
+void Grabber::init() {
+    grabberServo.attach(grabberServoPin);
+    grabberServo.write(servoAngle);
+}
 
 void Grabber::setAngle(uint8_t degrees) {
     servoAngle = clampRange(degrees);

--- a/grabber.cpp
+++ b/grabber.cpp
@@ -1,0 +1,45 @@
+#include "include/grabber.hpp"
+
+#include <Servo.h>
+
+static constexpr uint8_t grabberServoPin = 6;
+
+static uint8_t servoAngle = 0;
+
+static Servo grabberServo;
+
+static uint8_t clampRange(uint8_t input) {
+    // clamps a uint8_t to 0 - 180 range
+    return input < 0 ? 0 : input > 180 ? 180 : input;
+}
+
+void Grabber::init() { grabberServo.attach(grabberServoPin); }
+
+void Grabber::setAngle(uint8_t degrees) {
+    servoAngle = clampRange(degrees);
+    grabberServo.write(servoAngle);
+}
+
+void Grabber::changeAngle(int16_t degrees) {
+    if (degrees == 0) {
+        return;
+    }
+    servoAngle = clampRange(servoAngle + degrees);
+    grabberServo.write(servoAngle);
+}
+
+void Grabber::moveUp(uint8_t degrees) {
+    if (degrees == 0) {
+        return;
+    }
+    servoAngle = clampRange(servoAngle + degrees);
+    grabberServo.write(servoAngle);
+}
+
+void Grabber::moveDown(uint8_t degrees) {
+    if (degrees == 0) {
+        return;
+    }
+    servoAngle = clampRange(servoAngle - degrees);
+    grabberServo.write(servoAngle);
+}

--- a/grabber.cpp
+++ b/grabber.cpp
@@ -1,48 +1,47 @@
 #include "include/grabber.hpp"
+#include "include/util.hpp"
 
 #include <Servo.h>
 
 static constexpr uint8_t grabberServoPin = 3;
 
+static uint8_t servoDeadzone = 0;
 static uint8_t servoAngle = 0;
 
 static Servo grabberServo;
-
-static uint8_t clampRange(uint8_t input) {
-    // clamps a uint8_t to 0 - 180 range
-    return input < 0 ? 0 : input > 180 ? 180 : input;
-}
 
 void Grabber::init() {
     grabberServo.attach(grabberServoPin);
     grabberServo.write(servoAngle);
 }
 
+void Grabber::setDeadzone(uint8_t deadzone) { servoDeadzone = deadzone; }
+
 void Grabber::setAngle(uint8_t degrees) {
-    servoAngle = clampRange(degrees);
+    servoAngle = Util::clamp_8(degrees, 0, 180);
     grabberServo.write(servoAngle);
 }
 
 void Grabber::changeAngle(int16_t degrees) {
-    if (degrees == 0) {
+    if (degrees < servoDeadzone) {
         return;
     }
-    servoAngle = clampRange(servoAngle + degrees);
+    servoAngle = Util::clamp_16(servoAngle + degrees, 0, 180);
     grabberServo.write(servoAngle);
 }
 
 void Grabber::moveUp(uint8_t degrees) {
-    if (degrees == 0) {
+    if (degrees < servoDeadzone) {
         return;
     }
-    servoAngle = clampRange(servoAngle + degrees);
+    servoAngle = Util::clamp_16(servoAngle + degrees, 0, 180);
     grabberServo.write(servoAngle);
 }
 
 void Grabber::moveDown(uint8_t degrees) {
-    if (degrees == 0) {
+    if (degrees < servoDeadzone) {
         return;
     }
-    servoAngle = clampRange(servoAngle - degrees);
+    servoAngle = Util::clamp_16(servoAngle - degrees, 0, 180);
     grabberServo.write(servoAngle);
 }

--- a/grabber.cpp
+++ b/grabber.cpp
@@ -2,7 +2,7 @@
 
 #include <Servo.h>
 
-static constexpr uint8_t grabberServoPin = 6;
+static constexpr uint8_t grabberServoPin = 3;
 
 static uint8_t servoAngle = 0;
 

--- a/include/grabber.hpp
+++ b/include/grabber.hpp
@@ -4,13 +4,16 @@
 
 namespace Grabber {
 
-    void init();
+void init();
 
-    void setAngle(uint8_t degrees);
+void setDeadzone(uint8_t deadzone);
 
-    void changeAngle(int16_t degrees);
+void setAngle(uint8_t degrees);
 
-    void moveUp(uint8_t degrees);
+void changeAngle(int16_t degrees);
 
-    void moveDown(uint8_t degrees);
-}
+void moveUp(uint8_t degrees);
+
+void moveDown(uint8_t degrees);
+
+} // namespace Grabber

--- a/include/grabber.hpp
+++ b/include/grabber.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <Arduino.h>
+
+namespace Grabber {
+
+    void init();
+
+    void setAngle(uint8_t degrees);
+
+    void changeAngle(int16_t degrees);
+
+    void moveUp(uint8_t degrees);
+
+    void moveDown(uint8_t degrees);
+}

--- a/include/grabber.hpp
+++ b/include/grabber.hpp
@@ -4,16 +4,27 @@
 
 namespace Grabber {
 
+/// Initializes the grabber module
 void init();
 
+/// Sets the deadzone for the grabber
 void setDeadzone(uint8_t deadzone);
 
+/// Sets an absolute angle for the grabber.
+/// Will be clamped to minimum and maximum angles.
 void setAngle(uint8_t degrees);
 
+/// Changes the grabber angle.
+/// Positive values move up, negative values move down.
+/// After calculating the new angle, it will be clamped.
 void changeAngle(int16_t degrees);
 
+/// Moves the grabber up. Equivalent to changeAngle with a positive angle.
+/// Slightly more optimized.
 void moveUp(uint8_t degrees);
 
+/// Moves the grabber down. Equivalent to changeAngle with a negative angle.
+/// Slightly more optimized.
 void moveDown(uint8_t degrees);
 
 } // namespace Grabber

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <Arduino.h>
+
+namespace Util {
+
+inline int16_t copySign(int16_t dest, int16_t source) {
+    return source >= 0 ? dest : -dest;
+}
+
+inline uint8_t deadzone_8(uint8_t val, uint8_t deadzone) {
+    return val < deadzone ? 0 : val;
+}
+
+inline int16_t deadzone_16(int16_t val, uint8_t deadzone) {
+    return abs(val) < deadzone ? 0 : val;
+}
+
+inline uint8_t clamp_8(uint8_t input, uint8_t min, uint8_t max) {
+    return input < min ? min : input > max ? max : input;
+}
+
+inline int16_t clamp_16(int16_t input, int16_t min, int16_t max) {
+    return input < min ? min : input > max ? max : input;
+}
+
+} // namespace Util

--- a/main.ino
+++ b/main.ino
@@ -1,24 +1,38 @@
 #include "lib/DriverStation.h"
 
 #include "include/drivebase.hpp"
-#include "include/tasks.hpp"
 #include "include/encoders.hpp"
+#include "include/grabber.hpp"
+#include "include/tasks.hpp"
 
 static ElegooCar *joebot = new ElegooCar();
 static DriverStation *ds = new DriverStation();
 
-static constexpr uint8_t deadzone = 32;
+static constexpr uint8_t DRIVEBASE_DEADZONE = 32;
+
+static constexpr uint8_t GRABBER_DEADZONE = 5;
+static constexpr float GRABBER_COEFFICIENT = 0.3;
 
 void setup() {
     Serial.begin(115200);
+
     Drivebase::init(joebot);
-    Drivebase::setDeadzone(deadzone);
+    Drivebase::setDeadzone(DRIVEBASE_DEADZONE);
+
     Encoders::init();
+
+    Grabber::init();
+    Grabber::setDeadzone(GRABBER_DEADZONE);
 }
 
 static void autonomous() {}
 
-static void teleop() { Drivebase::arcadeDrive(ds->getLY(), ds->getLX()); }
+static void teleop() {
+    Drivebase::arcadeDrive(ds->getLY(), ds->getLX());
+    
+    int16_t triggerDiff = (int16_t)ds->getLTrig() - (int16_t)ds->getRTrig();
+    Grabber::changeAngle(triggerDiff * GRABBER_COEFFICIENT);
+}
 
 void loop() {
     // update the DriverStation class - this will check if there is new data


### PR DESCRIPTION
This adds a module to control a servo on pin 3 (changeable with a constant), which will be used for the robot's grabber. Currently, it's mapped so LT moves up and RT moves down. Grabber.cpp constants allow controlling the servo pin, the minimum angle and the maximum angle (anything outside this range will be clamped). Main.ino constants allow controlling the sensitivity (as a float coefficient, currently 0.3) and the deadzone (applied after sensitivity calculations, currently 5). Deadzone can also be changed dynamically with a call to Grabber::setDeadzone.