### PR TITLE
Drivebase: use util.hpp

### DIFF
--- a/drivebase.cpp
+++ b/drivebase.cpp
@@ -1,30 +1,23 @@
 #include "include/drivebase.hpp"
+#include "include/util.hpp"
 
 static ElegooCar *m_car;
 static uint8_t m_deadzone = 0;
-
-static constexpr int16_t copySign(int16_t dest, int16_t source) {
-    return source >= 0 ? dest : -dest;
-}
-
-static constexpr int16_t applyDeadzone(int16_t val, uint8_t deadzone) {
-    return abs(val) < deadzone ? 0 : val;
-}
 
 void Drivebase::init(ElegooCar *car) { m_car = car; }
 
 void Drivebase::setDeadzone(uint8_t deadzone) { m_deadzone = deadzone; }
 
 void Drivebase::tankDrive(int16_t left, int16_t right) {
-    left = applyDeadzone(left, m_deadzone);
-    right = applyDeadzone(right, m_deadzone);
+    left = Util::deadzone_16(left, m_deadzone);
+    right = Util::deadzone_16(right, m_deadzone);
     m_car->setSpeed(left, right);
 }
 
 void Drivebase::arcadeDrive(int16_t y, int16_t x) {
     int16_t left, right;
 
-    int16_t maxInput = copySign(max(abs(y), abs(x)), y);
+    int16_t maxInput = Util::copySign(max(abs(y), abs(x)), y);
 
     if (y >= 0) {
         // First quadrant, else second quadrant
@@ -46,8 +39,8 @@ void Drivebase::arcadeDrive(int16_t y, int16_t x) {
         }
     }
 
-    left = applyDeadzone(left, m_deadzone);
-    right = applyDeadzone(right, m_deadzone);
+    left = Util::deadzone_16(left, m_deadzone);
+    right = Util::deadzone_16(right, m_deadzone);
     m_car->setSpeed(left, right);
 }
 


### PR DESCRIPTION
This PR uses inline functions defined in util.hpp instead of static constexpr functions defined in drivebase.cpp. No functional changes, just reduces the size drivebase.cpp by moving common inline functions to a shared header file.