### PR TITLE
Grabber: interpolate smooth motion using a task

### DIFF
--- a/grabber.cpp
+++ b/grabber.cpp
@@ -69,22 +69,22 @@ bool Grabber::update(unsigned long taskStart) {
         return false;
     }
     if (currentValue < grabberServoAngle) {
-        uint8_t newVal = floor(currentValue + SPEED_PER_MS * timeDiff);
-        if (newVal > grabberServoAngle) {
-            newVal = grabberServoAngle;
+        uint8_t newValue = floor(currentValue + SPEED_PER_MS * timeDiff);
+        if (newValue > grabberServoAngle) {
+            newValue = grabberServoAngle;
         }
-        if (newVal != currentValue) {
+        if (newValue != currentValue) {
             lastUpdate = millis();
-            grabberServo.write(newVal);
+            grabberServo.write(newValue);
         }
     } else {
-        uint8_t newVal = ceil(currentValue - SPEED_PER_MS * timeDiff);
-        if (newVal < grabberServoAngle) {
-            newVal = grabberServoAngle;
+        uint8_t newValue = ceil(currentValue - SPEED_PER_MS * timeDiff);
+        if (newValue < grabberServoAngle) {
+            newValue = grabberServoAngle;
         }
-        if (newVal != currentValue) {
+        if (newValue != currentValue) {
             lastUpdate = millis();
-            grabberServo.write(newVal);
+            grabberServo.write(newValue);
         }
     }
     return false;

--- a/grabber.cpp
+++ b/grabber.cpp
@@ -62,8 +62,11 @@ void Grabber::moveDown(uint8_t degrees) {
 bool Grabber::update(unsigned long taskStart) {
     constexpr float SPEED_PER_MS = 0.1;
 
-    const int currentValue = grabberServo.read();
     const unsigned long timeDiff = millis() - lastUpdate;
+    if (timeDiff == 0) {
+        return false;
+    }
+    const int currentValue = grabberServo.read();
     if (currentValue == grabberServoAngle) {
         lastUpdate = millis();
         return false;

--- a/include/grabber.hpp
+++ b/include/grabber.hpp
@@ -27,4 +27,8 @@ void moveUp(uint8_t degrees);
 /// Slightly more optimized.
 void moveDown(uint8_t degrees);
 
+/// Sends a new value to the servo. Should be called repeatedly for smooth
+/// motion.
+bool update(unsigned long taskStart = 0);
+
 } // namespace Grabber

--- a/main.ino
+++ b/main.ino
@@ -23,6 +23,8 @@ void setup() {
 
     Grabber::init();
     Grabber::setDeadzone(GRABBER_DEADZONE);
+
+    Tasks::schedule(Grabber::update);
 }
 
 static void autonomous() {}


### PR DESCRIPTION
This PR uses a new Grabber function and a task to interpolate values during grabber motion, reducing the stuttering that occurs because controller input is only received every 50ms.

It does this by creating a function that writes incremental changes to the servo, based on a constant rate and the time since it was last called. Then, a task is scheduled that repeatedly calls this function every run through loop for the entire program duration.

It's possible to save a task slot by only scheduling the task when necessary (i.e. when there's a change to the servo angle), but the added complexity may not be worth the minimal gains. There are tons of task slots to spare right now so I'll leave this for a future PR if necessary.