### PR TITLE
Tasks: Log on descheduled task

### DIFF
--- a/tasks.cpp
+++ b/tasks.cpp
@@ -50,6 +50,8 @@ bool Tasks::schedule(bool (*fn)(unsigned long), unsigned long duration,
 void Tasks::run() {
     for (int i = 0; i < numSlots; i++) {
         if (taskSlots[i].run()) {
+            Serial.print("Descheduling task ");
+            Serial.println(i);
             taskSlots[i].done();
         }
     }


### PR DESCRIPTION
Adds a print message when a task is descheduled.

There's already a message when a task is scheduled, so a deschedule message is helpful for debugging tasks that frequently schedule and deschedule.