### PR TITLE
Grabber: don't use a task for updates

### DIFF
--- a/grabber.cpp
+++ b/grabber.cpp
@@ -59,17 +59,17 @@ void Grabber::moveDown(uint8_t degrees) {
     // grabberServo.write(grabberServoAngle);
 }
 
-bool Grabber::update(unsigned long taskStart) {
+void Grabber::update() {
     constexpr float SPEED_PER_MS = 0.1;
 
     const unsigned long timeDiff = millis() - lastUpdate;
     if (timeDiff == 0) {
-        return false;
+        return;
     }
     const int currentValue = grabberServo.read();
     if (currentValue == grabberServoAngle) {
         lastUpdate = millis();
-        return false;
+        return;
     }
     if (currentValue < grabberServoAngle) {
         uint8_t newValue = floor(currentValue + SPEED_PER_MS * timeDiff);
@@ -90,5 +90,5 @@ bool Grabber::update(unsigned long taskStart) {
             grabberServo.write(newValue);
         }
     }
-    return false;
+    return;
 }

--- a/include/grabber.hpp
+++ b/include/grabber.hpp
@@ -29,6 +29,6 @@ void moveDown(uint8_t degrees);
 
 /// Sends a new value to the servo. Should be called repeatedly for smooth
 /// motion.
-bool update(unsigned long taskStart = 0);
+void update();
 
 } // namespace Grabber

--- a/main.ino
+++ b/main.ino
@@ -23,8 +23,6 @@ void setup() {
 
     Grabber::init();
     Grabber::setDeadzone(GRABBER_DEADZONE);
-
-    Tasks::schedule(Grabber::update);
 }
 
 static void autonomous() {}
@@ -59,6 +57,8 @@ void loop() {
             break;
         }
     }
+
+    Grabber::update();
 
     Tasks::run();
 }


### PR DESCRIPTION
Instead of scheduling a task that never gets descheduled in setup, this PR just puts the grabber update call at the bottom of loop. Functionally equivalent, more performant, and saves a task slot.